### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ go mod download
 
 # Build go-ipfs with the plugin
 make build
+
+# If an error occurs, try
+go mod tidy
+make build
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # go-ipfs-healthcheck
 
-**NOTE: This currently works with go-ipfs version 0.8 and 0.10. Other versions have not been tested.**
-
-**TODO**
-
-- [ ] Compatiblity with go-ipfs 9
-- [ ] Use multiaddress for healthcheck endpoint
-
-A plugin for [go-ipfs](https://github.com/ipfs/go-ipfs) that serves a healthcheck endpoint which returns the status of the IPFS node.
-
 # Installation
 
 This is a preloaded plugin built in-tree into go-ipfs when it's compiled.
@@ -42,6 +33,12 @@ Run IPFS and check its status.
 ./cmd/ipfs/ipfs daemon
 curl -X GET http://localhost:8011
 ```
+
+# Future work
+
+- [ ] Use `ipfs dag stat` for healthcheck endpoint (See https://github.com/ipfs/go-ipfs/pull/8429/files)
+
+A plugin for [go-ipfs](https://github.com/ipfs/go-ipfs) that serves a healthcheck endpoint which returns the status of the IPFS node.
 
 # Resources
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-ipfs-healthcheck
 
+A plugin for [go-ipfs](https://github.com/ipfs/go-ipfs) that serves a healthcheck endpoint which returns the status of the IPFS node.
+
 # Installation
 
 This is a preloaded plugin built in-tree into go-ipfs when it's compiled.
@@ -37,8 +39,6 @@ curl -X GET http://localhost:8011
 # Future work
 
 - [ ] Use `ipfs dag stat` for healthcheck endpoint (See https://github.com/ipfs/go-ipfs/pull/8429/files)
-
-A plugin for [go-ipfs](https://github.com/ipfs/go-ipfs) that serves a healthcheck endpoint which returns the status of the IPFS node.
 
 # Resources
 


### PR DESCRIPTION
- Removed note about versions. Appears to work on all recent versions.
- Updated note about future work to link to how it is done in the go-ipfs Dockerfile
  - Note: AWS load balancers still require healthchecks via a port and endpoint so the Dockerfile healthcheck is no sufficient for some cloud setups